### PR TITLE
DatasetDescriptor from directory

### DIFF
--- a/deepvcd/applications/trainAlexNet.py
+++ b/deepvcd/applications/trainAlexNet.py
@@ -13,7 +13,7 @@ from deepvcd.helpers.image import read_image, one_hot
 from deepvcd.callbacks import NumpyEncoder
 import deepvcd.models.alexnet
 from deepvcd.models.alexnet.AlexNet import preprocess_train, preprocess_predict
-from deepvcd.dataset.descriptor import YAMLLoader
+from deepvcd.dataset.descriptor import YAMLLoader, DirectoryLoader
 
 
 log = logging.getLogger(__name__)
@@ -84,8 +84,13 @@ def _main(dataset_descriptor: str,
         from datetime import datetime
         seed = datetime.now().microsecond
 
-    log.info("Loading dataset from '{filename}'".format(filename=dataset_descriptor))
-    deepvcd_ds = YAMLLoader.read(dataset_descriptor)
+    deepvcd_ds = None
+    if pathlib.Path(dataset_descriptor).is_file():
+        log.info("Loading dataset from descriptor file '{filename}'".format(filename=dataset_descriptor))
+        deepvcd_ds = YAMLLoader.read(yaml_file=dataset_descriptor)
+    if pathlib.Path(dataset_descriptor).is_dir():
+        log.info("Loading dataset from directory '{directory}'".format(directory=dataset_descriptor))
+        deepvcd_ds = DirectoryLoader.load(dataset_dir=dataset_descriptor)
     num_classes = len(deepvcd_ds.get_labels())
     num_train_samples = len(deepvcd_ds.get_train_images())
 
@@ -209,7 +214,7 @@ if __name__ == '__main__':
                         required=False)
     parser.add_argument('dataset',
                         type=str,
-                        help='Path to dataset descriptor yaml.',
+                        help='Path to dataset descriptor yaml or directory following a dataset structure (see documentation).',
                         default=None)
     parser.add_argument('model_dest',
                         type=str,

--- a/deepvcd/dataset/descriptor.py
+++ b/deepvcd/dataset/descriptor.py
@@ -4,6 +4,7 @@ import pathlib
 import numpy as np
 import random
 import logging
+from abc import ABC, abstractmethod
 
 import yaml
 from tqdm import tqdm
@@ -195,7 +196,12 @@ def get_cross_val_folds(ds_descriptor, n_folds=4, seed=None):
     return fold_descrs
 
 
-class YAMLLoader(object):
+class DescriptorLoader(ABC):
+    @abstractmethod
+    def get_dataset(self) -> DatasetDescriptor:
+        pass
+
+class YAMLLoader(DescriptorLoader):
     def __init__(self, yaml_file, basepath=None) -> None:
         """
         Loads a DatasetDescriptor object from a yaml file. Use the static `read` method for convenience.
@@ -205,7 +211,7 @@ class YAMLLoader(object):
         self.yaml_file = yaml_file
         self.basepath = basepath
 
-    def get_dataset(self):
+    def get_dataset(self) -> DatasetDescriptor:
         data = yaml.load(open(self.yaml_file, 'r'), Loader=Loader)
         if self.basepath is not None:
             basepath = self.basepath
@@ -238,13 +244,13 @@ class YAMLLoader(object):
         return YAMLLoader(yaml_file, basepath=basepath).get_dataset()
 
 
-class DirectoryLoader(object):
+class DirectoryLoader(DescriptorLoader):
     def __init__(self, dataset_path:str) -> None:
         self.dataset_dir = pathlib.Path(dataset_path)
         if not self.dataset_dir.is_dir():
             raise ValueError("Dataset path #{0}' is not a valid path!".format(dataset_path))
 
-    def get_dataset(self):
+    def get_dataset(self) -> DatasetDescriptor:
         name = self.dataset_dir.name
         version = "undefined"
         dataset = DatasetDescriptor(name=name, version=version, basepath=str(self.dataset_dir))

--- a/deepvcd/dataset/descriptor.py
+++ b/deepvcd/dataset/descriptor.py
@@ -266,7 +266,7 @@ class DirectoryLoader(DescriptorLoader):
                         categories.append(class_dir.name)
 
                 for category in tqdm(categories):
-                    fnames = [p.resolve() for p in pathlib.Path(class_dir).glob("**/*") if p.suffix.lower() in {".jpg", ".jpeg", ".png"}]
+                    fnames = [p.resolve() for p in pathlib.Path(subset_dir / category).glob("**/*") if p.suffix.lower() in {".jpg", ".jpeg", ".png"}]
                     dataset.add_labeled_images(subset=subset, category=category, fnames=fnames)
 
         return dataset


### PR DESCRIPTION
- adds a `dataset.descriptor.DirectoryLoader` class that allows to instantiate a `DatasetDescriptor` by iterating over a directory following the structure:
   ```
      dataset_name/
      ...train
      ......class_a/
      .........a_image_1.jpg
      .........a_image_2.jpg
      ......class_b/
      .........b_image_1.jpg
      .........b_image_2.jpg
      ...val
      ......class_a/
      .........a_image_3.jpg
      .........a_image_4.jpg
      ......class_b/
      .........b_image_3.jpg
      .........b_image_4.jpg
      ...test
      ......class_a/
      .........a_image_5.jpg
      .........a_image_6.jpg
      ......class_b/
      .........b_image_5.jpg
      .........b_image_6.jpg      
   ```
   `val` and `test` directories are optional.

- `DirectoryLoader` and `YAMLLoader` inherit from abstract `DescriptorLoader` base class
- `trainAlexNet.py` can use either descriptor loader