### PR TITLE
Select optimization metric

### DIFF
--- a/deepvcd/applications/trainAlexNet.py
+++ b/deepvcd/applications/trainAlexNet.py
@@ -3,11 +3,13 @@ import logging
 import os
 import pathlib
 import json
+import ast
 
 import tensorflow as tf
 from tensorflow.keras.optimizers import SGD
 from tensorflow.keras.callbacks import ReduceLROnPlateau, EarlyStopping, ModelCheckpoint
 from tensorflow.keras import losses
+from tensorflow.keras import metrics
 
 from deepvcd.helpers.image import read_image, one_hot
 from deepvcd.callbacks import NumpyEncoder
@@ -26,7 +28,7 @@ AUTOTUNE = tf.data.AUTOTUNE
 def train_alexnet(train_ds,
                   num_classes,
                   norm="lrn",
-                  metric="accuracy", 
+                  metric="CategoricalAccuracy", 
                   input_size=227,
                   val_ds=None,
                   max_epochs=90,
@@ -44,10 +46,9 @@ def train_alexnet(train_ds,
     momentum = 0.9  # following Krizhevsky2012
 
     optimizer = SGD(learning_rate=initial_lr, momentum=momentum, weight_decay=decay, nesterov=False)
-    #optimizer = "adam"
     loss = losses.categorical_crossentropy
-    #loss = losses.sparse_categorical_crossentropy
     metrics = [metric]
+
     model.compile(
         optimizer=optimizer,
         loss=loss,
@@ -78,7 +79,8 @@ def _main(dataset_descriptor: str,
           norm: str="lrn",
           input_size: int=227,
           max_epochs: int=90,
-          monitor: str="accuracy",
+          metric: str="CategoricalAccuracy",
+          metric_args: dict={},
           checkpoints_dest: str=None,
           seed=None,
           model_weights_fname: str = None
@@ -133,20 +135,22 @@ def _main(dataset_descriptor: str,
 
     callbacks = []
 
-    _monitor = monitor if not val_ds else f"val_{monitor}"
+    #monitor_name = metric if not val_ds else f"val_{metric}"
+    metric_cls = getattr(metrics, metric)
+    metric_obj = metric_cls(**metric_args)
     # Krizhevsky2012: "divide the learning rate by 10 when the validation error rate stopped improving"
-    reduce_lr_cb = ReduceLROnPlateau(_monitor,
+    reduce_lr_cb = ReduceLROnPlateau(monitor="val_"+metric_obj.name,
                                      mode='auto',
                                      factor=0.1,  # divide by 10
                                      patience=5,
-                                     min_delta=0.005,
+                                     min_delta=0.001,
                                      cooldown=10,
                                      min_lr=0.00001,  # we reduce lr at max three times
                                      verbose=1)
     callbacks.append(reduce_lr_cb)
 
     # stop training if no more improvement
-    early_stop_cb = EarlyStopping(_monitor,
+    early_stop_cb = EarlyStopping(monitor="val_"+metric_obj.name,
                                   mode='auto',
                                   min_delta=0.0,
                                   patience=16,
@@ -158,8 +162,8 @@ def _main(dataset_descriptor: str,
     callbacks.append(early_stop_cb)
 
     if checkpoints_dest is not None:
-        model_checkpoints_cb = ModelCheckpoint(filepath=os.path.join(checkpoints_dest, "AlexNetFlat.epoch-{{epoch:02d}}_{label}-{{{monitor}:.2f}}.hdf5".format(label=_monitor.replace('_',''), monitor=_monitor)),
-                                               monitor=_monitor,
+        model_checkpoints_cb = ModelCheckpoint(filepath=os.path.join(checkpoints_dest, "AlexNetFlat.epoch-{{epoch:02d}}_{label}-{{{monitor}:.2f}}.hdf5".format(label=metric_obj.name.replace('_',''), monitor="val_"+metric_obj.name)),
+                                               monitor="val_"+metric_obj.name,
                                                verbose=0,
                                                save_best_only=True,
                                                save_weights_only=True,
@@ -173,12 +177,15 @@ def _main(dataset_descriptor: str,
     alexnet, history = train_alexnet(train_ds=train_ds,
                                      num_classes=num_classes,
                                      norm=norm,
-                                     metric=monitor,
+                                     metric=metric_obj,
                                      input_size=input_size,
                                      val_ds=val_ds,
                                      max_epochs=max_epochs,
                                      callbacks=callbacks,
                                      )
+    val_loss, val_metric = alexnet.evaluate(val_ds)
+    log.info(f"Final validataion set results: {metric}={val_metric:.4f} (val_loss={val_loss:.4f})")
+
     if model_weights_fname:
         dest_dir = pathlib.Path(model_weights_fname).parent.absolute()
         if not dest_dir.exists():
@@ -233,33 +240,50 @@ if __name__ == '__main__':
                         help="Train for x epochs",
                         default=200,
                         required=False)
-    parser.add_argument("-m", "--monitor",
-                        dest="monitor",
+    parser.add_argument("-m", "--metric",
+                        dest="metric",
                         type=str,
-                        help="Metric to be used for monitoring validation data improvements during training (default: accuracy).",
-                        default="accuracy",
+                        help="Metric to be used for monitoring validation data improvements during training (default: CategoricalAccuracy).",
+                        default="CategoricalAccuracy",
                         required=False)
+    parser.add_argument("--metric_args",
+                        dest="metric_args",
+                        help="",
+                        type=str,
+                        nargs='*',
+                        default=None)
     parser.add_argument("-c", "--checkpoints_dest",
                         dest="checkpoints",
                         type=str,
                         help="Path to checkpoints directory. If set, incremental model improvements are stored during training.",
                         default=None,
                         required=False)
-    parser.add_argument("dataset",
+    parser.add_argument("-d", "--dataset",
+                        dest="dataset",
                         type=str,
                         help="Path to dataset descriptor yaml or directory following a dataset structure (see documentation).",
-                        default=None)
-    parser.add_argument("model_dest",
+                        default=None,
+                        required=True)
+    parser.add_argument("-w", "--weights",
+                        dest="weights",
                         type=str,
-                        help="Path to final model file.",
-                        default=None)
+                        help="Path to hdf5 file for storing optimized model weights after training.",
+                        default=None,
+                        required=True)
     args = parser.parse_args()
+
+    # parse metric_args string to dict:
+    metric_args = {}
+    if args.metric_args is not None:
+        metric_args = dict([(k,v) for k,v in (pair.split('=') for pair in args.metric_args)])
+        #metric_args = dict((k, ast.literal_eval(v)) for k, v in (pair.split('=') for pair in args.metric_args))
 
     _main(dataset_descriptor=args.dataset,
           norm=None if args.norm.lower()=="none" else args.norm,
           input_size=args.input_size,
           max_epochs=args.epochs,
-          monitor=args.monitor,
+          metric=args.metric,
+          metric_args=metric_args,
           checkpoints_dest=args.checkpoints,
           seed=args.seed,
-          model_weights_fname=args.model_dest)
+          model_weights_fname=args.weights)

--- a/deepvcd/applications/trainAlexNet.py
+++ b/deepvcd/applications/trainAlexNet.py
@@ -26,6 +26,7 @@ AUTOTUNE = tf.data.AUTOTUNE
 def train_alexnet(train_ds,
                   num_classes,
                   norm="lrn",
+                  metric="accuracy", 
                   input_size=227,
                   val_ds=None,
                   max_epochs=90,
@@ -46,7 +47,7 @@ def train_alexnet(train_ds,
     #optimizer = "adam"
     loss = losses.categorical_crossentropy
     #loss = losses.sparse_categorical_crossentropy
-    metrics = ['accuracy']  # FIXME: make this configurable, add mAP
+    metrics = [metric]
     model.compile(
         optimizer=optimizer,
         loss=loss,
@@ -172,6 +173,7 @@ def _main(dataset_descriptor: str,
     alexnet, history = train_alexnet(train_ds=train_ds,
                                      num_classes=num_classes,
                                      norm=norm,
+                                     metric=monitor,
                                      input_size=input_size,
                                      val_ds=val_ds,
                                      max_epochs=max_epochs,


### PR DESCRIPTION
Allows to select optimzation metric to be used during training from command line via:
`-m/--metric <MetricClass>` 
where `MetricClass` needs to a be the class name of a metric available in `tf.keras.metrics` (e.g. `AUC`).
Metric parameters can be configured using the `--metric_args` command line parameter:
`--metric_args param1=val1 param2=val2` ,
e.g. `--metric_args name=mAP curve=PR multi_label=True num_thresholds=200` .

The selected metric is then used for evaluating training progress (reducing learning rate on plateau, early stopping, progress printing). By default, `tf.keras.metrics.CategoricalAccuracy` is used.