### PR TITLE
fixes #10

### DIFF
--- a/deepvcd/callbacks.py
+++ b/deepvcd/callbacks.py
@@ -5,10 +5,24 @@ import logging
 
 import numpy as np
 
-import keras.backend as K
-from keras.callbacks import Callback
+import tensorflow.keras.backend as K
+from tensorflow.keras.callbacks import Callback
+from tensorflow.keras import metrics
 
 log = logging.getLogger(__name__)
+
+
+callback_mode_for_metric = {
+    getattr(metrics, "Accuracy"): "max",
+    getattr(metrics, "BinaryAccuracy"): "max",
+    getattr(metrics, "CategoricalAccuracy"): "max",
+    getattr(metrics, "TopKCategoricalAccuracy"): "max",
+    getattr(metrics, "AUC"): "max",
+    getattr(metrics, "Precision"): "max",
+    getattr(metrics, "PrecisionAtRecall"): "max",
+    getattr(metrics, "Recall"): "max",
+    getattr(metrics, "RecallAtPrecision"): "max"
+}
 
 
 class StepLearningRate(Callback):


### PR DESCRIPTION
for most commonly used metrics, the mode is stored in `callbacks.py`:
https://github.com/chrstn-hntschl/deepvcd/blob/90636d3ecd721f5e07a404488e62b99f27bfbc41/deepvcd/callbacks.py#L15-L25)