### PR TITLE
Bugfix predict on directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ _build:
 	docker build -t chrstn_hntschl/deepvcd:tf-$(TF_VER)-$(TAG) --build-arg TF_VER=$(TF_VER) --build-arg USER=$(USER) -f $(DOCKER_FILE) .
 
 dev: _build 
-	docker run $(DOCKER_FLAGS) --rm -it -v $(CURDIR):/home/$(USER)/deepvcd -v $(DATA):/data/datasets -v $(CHECKPOINTS):/data/checkpoints --workdir /home/$(USER)/deepvcd --env PYTHONPATH=/home/$(USER)/deepvcd chrstn_hntschl/deepvcd:tf-$(TF_VER)-$(TAG) /bin/bash
+	docker run $(DOCKER_FLAGS) --rm -it --memory=300g --memory-swap=300g -v $(CURDIR):/home/$(USER)/deepvcd -v $(DATA):/data/datasets -v $(CHECKPOINTS):/data/checkpoints --workdir /home/$(USER)/deepvcd --env PYTHONPATH=/home/$(USER)/deepvcd chrstn_hntschl/deepvcd:tf-$(TF_VER)-$(TAG) /bin/bash
 

--- a/deepvcd/dataset/descriptor.py
+++ b/deepvcd/dataset/descriptor.py
@@ -245,8 +245,9 @@ class YAMLLoader(DescriptorLoader):
 
 
 class DirectoryLoader(DescriptorLoader):
-    def __init__(self, dataset_path:str) -> None:
+    def __init__(self, dataset_path:str, subsets:list=["train", "val", "test"]) -> None:
         self.dataset_dir = pathlib.Path(dataset_path)
+        self.subsets = subsets
         if not self.dataset_dir.is_dir():
             raise ValueError("Dataset path #{0}' is not a valid path!".format(dataset_path))
 
@@ -255,8 +256,7 @@ class DirectoryLoader(DescriptorLoader):
         version = "undefined"
         dataset = DatasetDescriptor(name=name, version=version, basepath=str(self.dataset_dir))
 
-        subsets = ["train", "val", "test"]
-        for subset in subsets:
+        for subset in self.subsets:
             subset_dir = self.dataset_dir / subset
             if subset_dir.is_dir():
                 log.info(f"Loading subset '{subset}'")

--- a/deepvcd/dataset/descriptor.py
+++ b/deepvcd/dataset/descriptor.py
@@ -272,5 +272,5 @@ class DirectoryLoader(DescriptorLoader):
         return dataset
 
     @staticmethod
-    def load(dataset_dir):
-        return DirectoryLoader(dataset_dir).get_dataset()
+    def load(dataset_dir:str, subsets:list):
+        return DirectoryLoader(dataset_dir, subsets).get_dataset()

--- a/deepvcd/dataset/descriptor.py
+++ b/deepvcd/dataset/descriptor.py
@@ -4,6 +4,7 @@ import pathlib
 import numpy as np
 import random
 import logging
+import json
 from abc import ABC, abstractmethod
 
 import yaml
@@ -83,7 +84,7 @@ class DatasetDescriptor(object):
         if category is None:
             return [os.path.join(self.basepath, fname) for fname in self.ground_truth[subset]['images'].values()]
         else:
-            posids = self.ground_truth[subset]['gt'][category]
+            posids = self.ground_truth[subset]['gt'].get(category, list())
 
             pos = [os.path.join(self.basepath, self.ground_truth[subset]['images'][id]) for id in posids]
 
@@ -91,7 +92,7 @@ class DatasetDescriptor(object):
                 return pos
             else:
                 if self.neg_category is not None:
-                    negids = self.ground_truth[subset]['gt'][self.neg_category]
+                    negids = self.ground_truth[subset]['gt'].get(self.neg_category, list())
                 else:
                     negids = list(set(self.ground_truth[subset]['images'].keys()) - set(posids))
 
@@ -256,15 +257,23 @@ class DirectoryLoader(DescriptorLoader):
         version = "undefined"
         dataset = DatasetDescriptor(name=name, version=version, basepath=str(self.dataset_dir))
 
+        concepts_file = self.dataset_dir / "concepts.json"
+        if concepts_file.exists():
+            categories = json.load(open(concepts_file, 'r'))
+            log.info(f"Loading concept names from concepts file.")
+        else:
+            train_dir = self.dataset_dir / "train"
+            log.info(f"Loading concept names from sub directories in (mandatory) 'train' directory.")
+            categories = list()
+            for class_dir in train_dir.iterdir():
+                if class_dir.is_dir():
+                    categories.append(class_dir.name)
+        log.info(f"Found {len(categories)} concepts in dataset.")
+
         for subset in self.subsets:
             subset_dir = self.dataset_dir / subset
             if subset_dir.is_dir():
                 log.info(f"Loading subset '{subset}'")
-                categories = list()
-                for class_dir in subset_dir.iterdir():
-                    if class_dir.is_dir():
-                        categories.append(class_dir.name)
-
                 for category in tqdm(categories):
                     fnames = [p.resolve() for p in pathlib.Path(subset_dir / category).glob("**/*") if p.suffix.lower() in {".jpg", ".jpeg", ".png"}]
                     dataset.add_labeled_images(subset=subset, category=category, fnames=fnames)

--- a/deepvcd/helpers/image.py
+++ b/deepvcd/helpers/image.py
@@ -14,9 +14,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import numpy as np
-
-from tensorflow.keras import backend as K
-from tensorflow.keras.preprocessing.image import img_to_array
+from tensorflow import keras
+from keras import backend as K
+from keras.preprocessing.image import img_to_array
 
 import tensorflow as tf
 
@@ -39,6 +39,8 @@ if pil_image is not None:
     # This method is new in version 1.1.3 (2013).
     if hasattr(pil_image, 'LANCZOS'):
         _PIL_INTERPOLATION_METHODS['lanczos'] = pil_image.LANCZOS
+else:
+    _PIL_INTERPOLATION_METHODS = {}
 
 
 def load_img(path, grayscale=False, target_size=None,

--- a/deepvcd/models/alexnet/AlexNet.py
+++ b/deepvcd/models/alexnet/AlexNet.py
@@ -352,15 +352,22 @@ def predict(deepvcd_ds, subset="val", weights="imagenet", input_size=227, norm="
 
 
 def _main(cli_args):
+    import pathlib
+    from deepvcd.dataset.descriptor import YAMLLoader, DirectoryLoader
+
     if cli_args.weights_files == "imagenet" or cli_args.weights_files == ["imagenet"]:
          log.info("Using pre-trained ILSVRC2012 weights")
          weights_files = ["imagenet"]
     else:
         weights_files=cli_args.weights_files
 
-    from deepvcd.dataset.descriptor import YAMLLoader
-    log.info("Loading dataset from descriptor '{0}'".format(cli_args.dataset))
-    deepvcd_ds = YAMLLoader.read(cli_args.dataset)
+    dataset_descriptor = cli_args.dataset
+    if pathlib.Path(dataset_descriptor).is_file():
+        log.info("Loading dataset from descriptor file '{filename}'".format(filename=dataset_descriptor))
+        deepvcd_ds = YAMLLoader.read(yaml_file=dataset_descriptor)
+    if pathlib.Path(dataset_descriptor).is_dir():
+        log.info("Loading dataset from directory '{directory}'".format(directory=dataset_descriptor))
+        deepvcd_ds = DirectoryLoader.load(dataset_dir=dataset_descriptor)
 
     scores = None
     for weights_file in weights_files:
@@ -405,7 +412,12 @@ if __name__ == '__main__':
     log.info("Keras version: {ver}".format(ver=keras.__version__))
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--dataset', help='Path to dataset descriptor yaml', dest='dataset', type=str, required=True)
+    parser.add_argument('-d', '--dataset', 
+                        help='Path to dataset descriptor yaml or directory following a dataset structure (see documentation).', 
+                        dest='dataset', 
+                        type=str, 
+                        default=None,
+                        required=True)
     parser.add_argument('-n', '--norm',
                         dest='norm',
                         type=str,

--- a/deepvcd/models/alexnet/AlexNet.py
+++ b/deepvcd/models/alexnet/AlexNet.py
@@ -346,11 +346,9 @@ def predict(deepvcd_ds, subset="val", weights="imagenet", input_size=227, norm="
                 ds_ = ds_.batch(128)
                 ds_ = ds_.cache()
                 ds_ = ds_.prefetch(buffer_size=tf.data.AUTOTUNE)
-                #model = model_class(include_top=True, input_shape=(input_size, input_size, 3), norm=norm, weights=weights, classes=num_classes)
                 scores[offset:min(offset+chunk_size,len(ds))] += model.predict(x=ds_,
                                         verbose=1)
                 cnt += 1
-                #model = None
                 gc.collect()
                 K.clear_session() 
     scores /= cnt

--- a/deepvcd/models/alexnet/AlexNet.py
+++ b/deepvcd/models/alexnet/AlexNet.py
@@ -1,21 +1,20 @@
 import os
-from termios import VLNEXT
 import warnings
 import logging
 import numpy as np
 
-from tensorflow.keras import backend as K
-from tensorflow.keras import Model, Input
-from tensorflow.keras.layers import Dense, Flatten, Dropout, MaxPooling2D, Conv2D, ZeroPadding2D, BatchNormalization, Lambda, Activation
+from tensorflow import keras
+from keras import backend as K
+from keras import Model, Input
+from keras.layers import Dense, Flatten, Dropout, MaxPooling2D, Conv2D, ZeroPadding2D, BatchNormalization, Lambda, Activation
 from tensorflow.python.keras.utils import layer_utils
-from tensorflow.keras.initializers import Constant, RandomNormal
-from tensorflow.keras import regularizers
+from keras.initializers import Constant, RandomNormal
+from keras import regularizers
 import tensorflow as tf
 
 from keras.applications import imagenet_utils
 
-from deepvcd.metrics import top_k_error
-from deepvcd.helpers.image import read_image, one_hot
+from deepvcd.helpers.image import read_image
 from deepvcd.models.layers import LRN2D
 
 log = logging.getLogger(__name__)
@@ -309,12 +308,13 @@ def AlexNetFlat(include_top=True,
 
 
 def predict(deepvcd_ds, subset="val", weights="imagenet", input_size=227, norm="lrn", average_results=True):
+    import gc
+
     num_classes = len(deepvcd_ds.get_labels())
     model_class = globals()["AlexNetFlat"]
     model = model_class(include_top=True, input_shape=(input_size, input_size, 3), norm=norm, weights=weights, classes=num_classes)
 
     ds,_ = deepvcd_ds.get_tfdataset(subset=subset, shuffle_files=False)
-    ds = ds.map(lambda x,y: (read_image(x), y), num_parallel_calls=tf.data.AUTOTUNE)
    
     gt = list()
     for _, label in ds:
@@ -332,27 +332,36 @@ def predict(deepvcd_ds, subset="val", weights="imagenet", input_size=227, norm="
     #ilsvrc2012_mean = [0.48184115, 0.453552, 0.3977624]
     log.debug("Using mean={mean}".format(mean=ilsvrc2012_mean))
 
-    scores = list()
+    chunk_size = 50000
+    cnt = 0
+    scores = np.zeros((len(ds),num_classes))
     for region in regions:
         for flip in [False, True]:
-            ds_ = ds.map(lambda x, y: (preprocess_predict(x, mean=ilsvrc2012_mean, crop_region=region, horizontal_flip=flip), y), num_parallel_calls=tf.data.AUTOTUNE)
-            ds_ = ds_.map(lambda x,y: one_hot(x,y,num_classes))
-            ds_ = ds_.batch(256)
-            ds_ = ds_.prefetch(buffer_size=tf.data.AUTOTUNE)
-
             log.info("Computing model scores for region '{region} (flipped={flipped})'".format(region=region, flipped=flip))
-            scores_ = model.predict(x=ds_,
-                                   verbose=2)
-            scores.append(scores_)
-
-    avg_scores = sum(scores)
-    scores = avg_scores / (2 * len(scores))
+            for offset in range(0, len(ds), chunk_size):
+                ds_ = ds.skip(offset)
+                ds_ = ds_.take(chunk_size)
+                ds_ = ds_.map(lambda x,y: (read_image(x), y), num_parallel_calls=tf.data.AUTOTUNE)
+                ds_ = ds_.map(lambda x, y: preprocess_predict(x, mean=ilsvrc2012_mean, crop_region=region, horizontal_flip=flip), num_parallel_calls=tf.data.AUTOTUNE)
+                ds_ = ds_.batch(128)
+                ds_ = ds_.cache()
+                ds_ = ds_.prefetch(buffer_size=tf.data.AUTOTUNE)
+                #model = model_class(include_top=True, input_shape=(input_size, input_size, 3), norm=norm, weights=weights, classes=num_classes)
+                scores[offset:min(offset+chunk_size,len(ds))] += model.predict(x=ds_,
+                                        verbose=1)
+                cnt += 1
+                #model = None
+                gc.collect()
+                K.clear_session() 
+    scores /= cnt
+    log.info("returning.")
     return gt, scores
 
 
 def _main(cli_args):
     import pathlib
     from deepvcd.dataset.descriptor import YAMLLoader, DirectoryLoader
+    from deepvcd.metrics import top_k_error
 
     if cli_args.weights_files == "imagenet" or cli_args.weights_files == ["imagenet"]:
          log.info("Using pre-trained ILSVRC2012 weights")
@@ -375,11 +384,13 @@ def _main(cli_args):
     gt = None
     for weights_file in weights_files:
         log.info("Using weights from '{weights_file}'".format(weights_file=weights_file))
-        gt, scores_ = predict(norm=None if cli_args.norm.lower()=="none" else cli_args.norm,
-                              input_size=cli_args.input_size,
+        gt, scores_ = predict(deepvcd_ds=deepvcd_ds,
+                              subset=subset,
                               weights=weights_file,
-                              deepvcd_ds=deepvcd_ds,
+                              input_size=cli_args.input_size,
+                              norm=None if cli_args.norm.lower()=="none" else cli_args.norm,
                               average_results=True)
+        log.info("Computing top-k-error")
         top5error = top_k_error(y_true=gt, y_pred=scores_, k=5)
         log.info("Top-5-error-rate (single net): {top5error}".format(top5error=top5error))
 
@@ -426,7 +437,7 @@ if __name__ == '__main__':
                         dest='subset', 
                         type=str, 
                         default="test",
-                        required=True)    
+                        required=False)    
     parser.add_argument('-n', '--norm',
                         dest='norm',
                         type=str,

--- a/deepvcd/models/alexnet/AlexNet.py
+++ b/deepvcd/models/alexnet/AlexNet.py
@@ -361,12 +361,13 @@ def _main(cli_args):
         weights_files=cli_args.weights_files
 
     dataset_descriptor = cli_args.dataset
+    subset = cli_args.subset
     if pathlib.Path(dataset_descriptor).is_file():
         log.info("Loading dataset from descriptor file '{filename}'".format(filename=dataset_descriptor))
         deepvcd_ds = YAMLLoader.read(yaml_file=dataset_descriptor)
     elif pathlib.Path(dataset_descriptor).is_dir():
         log.info("Loading dataset from directory '{directory}'".format(directory=dataset_descriptor))
-        deepvcd_ds = DirectoryLoader.load(dataset_dir=dataset_descriptor)
+        deepvcd_ds = DirectoryLoader.load(dataset_dir=dataset_descriptor, subsets=[subset])
     else:
         raise ValueError(f"No such file or directory: '{dataset_descriptor}'")
 
@@ -420,6 +421,12 @@ if __name__ == '__main__':
                         type=str, 
                         default=None,
                         required=True)
+    parser.add_argument('-s', '--subset', 
+                        help="Subset to use for testing. Can be one of 'val' or 'test' (default).", 
+                        dest='subset', 
+                        type=str, 
+                        default="test",
+                        required=True)    
     parser.add_argument('-n', '--norm',
                         dest='norm',
                         type=str,


### PR DESCRIPTION
Prediction on large datasets (e.g. ImageNet-21k) was not possible due to high memory usage (>300g). This PR fixes the issue by:
- applying improved memory handling (i.e. split dataset into chunks and predict on chunks)
- allowing to load only subsets of a dataset (currently limited to DirectoryLoader)
- limiting docker dev container to max 300g main memory